### PR TITLE
Add support for unknown lock states

### DIFF
--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -123,10 +123,10 @@ class YaleBinarySensor2(Entity):
         """Return the state of the sensor."""
         state = self.yale_object["status1"]
         
-        if "device_status.dc_close" in state:
+        if "device_status.dc_close" in state or "device_status.lock" in state:
             self._is_on = False
             return YALE_DOOR_CONTACT_STATE_CLOSED
-        elif "device_status.dc_open" in state:
+        elif "device_status.dc_open" in state or "device_status.unlock" in state:
             self._is_on = True
             return YALE_DOOR_CONTACT_STATE_OPEN
         elif "device_status.tamper_open" in state:


### PR DESCRIPTION
Hi, thanks for this component! I set it up yesterday to track Yale Doorman lock state on Home Assistant. 
It works fine but I was getting the "unknown state" messages. This seems to fix it. 
I don't know if Yale has changed their API or if different locations/versions report different values, but I think it should be safe to support both?